### PR TITLE
Simple method of hiding loupe while scrolling

### DIFF
--- a/jquery.loupe.js
+++ b/jquery.loupe.js
@@ -8,7 +8,8 @@
 		var options = $.extend({
 			loupe: 'loupe',
 			width: 200,
-			height: 150
+			height: 150,
+			src: ''
 		}, arg || {});
 
 		return this.length ? this.each(function () {
@@ -58,7 +59,7 @@
 					position: 'absolute',
 					overflow: 'hidden'
 				})
-				.append($big = $('<img />').attr('src', $this.attr($this.is('img') ? 'src' : 'href')).css('position', 'absolute'))
+				.append($big = $('<img />').attr('src', options.src ? options.src : $this.attr($this.is('img') ? 'src' : 'href')).css('position', 'absolute'))
 				.mousemove(move)
 				.hide()
 				.appendTo('body');


### PR DESCRIPTION
It starts looking really annoying otherwise since the plugin isn't disabling all visible loupes before displaying a new one. Things get hairy when you have several louped images on one page.

Oh, and I left the compiling up to you.
