### PR TITLE
Clean-up for dynamic content

### DIFF
--- a/jquery.loupe.js
+++ b/jquery.loupe.js
@@ -15,10 +15,19 @@
 			var $this = $(this), $big, $loupe,
 				$small = $this.is('img') ? $this : $this.find('img:first'),
 				move, hide = function () { $loupe.hide(); },
-				time;
+				time, destroy, data;
 
-			if ($this.data('loupe') != null) {
-				return $this.data('loupe', arg);
+			data = $this.data('loupe');
+			if (data != null) {
+				if ('destroy' === arg) {
+					return data.destroy();
+				}
+				
+				data.enabled = arg;
+				return $this.data('loupe', data);
+			} else if ('destroy' === arg) {
+				// Nothing to destroy yet
+				return;
 			}
 
 			move = function (e) {
@@ -28,7 +37,7 @@
 					oW = options.width / 2,
 					oH = options.height / 2;
 
-				if (!$this.data('loupe') ||
+				if (!$this.data('loupe').enabled ||
 					e.pageX > sW + os.left + 10 || e.pageX < os.left - 10 ||
 					e.pageY > sH + os.top + 10 || e.pageY < os.top - 10) {
 					return hide();
@@ -58,10 +67,15 @@
 				.mousemove(move)
 				.hide()
 				.appendTo('body');
+			
+			destroy = function() {
+				$loupe.remove();
+				$this.unbind('.loupe').removeData('loupe');
+			};
 
-			$this.data('loupe', true)
-				.mouseenter(move)
-				.mouseout(function () {
+			$this.data('loupe', {destroy: destroy, enabled: true})
+				.bind('mouseenter.loupe', move)
+				.bind('mouseout.loupe', function () {
 					time = setTimeout(hide, 10);
 				});
 		}) : this;


### PR DESCRIPTION
This adds the possibility to destroy loupe instance + it's data.
I've implemented this because I use loupe with dynamic content, so it needs the ability to clean-up.

Example:

```
$(element).loupe('destroy').loupe();
```
